### PR TITLE
Move static functions to proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file, in reverse 
   ```
   use Tuupola\KsuidProxy as Ksuid;
 
+  $ksuid = KsuidProxy::generate();
   $ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
 
   $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,21 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## [0.2.0](https://github.com/tuupola/ksuid/compare/0.1.4...0.2.0) - unreleased
+### Changed
+- Moved static functions to proxy.
+  ```
+  use Tuupola\KsuidProxy as Ksuid;
+
+  $ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
+
+  $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
+  $ksuid = KsuidProxy::fromBytes($binary);
+  ```
+
 ## [0.1.4](https://github.com/tuupola/ksuid/compare/0.1.3...0.1.4) - 2018-12-09
 ### Fixed
-- Allow using tuupola/base62:^1.0.
+- Allow using tuupola/base62:^1.0
 
 ## [0.1.3](https://github.com/tuupola/ksuid/compare/0.1.2...0.1.3) - 2018-10-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,14 +21,12 @@ $ composer require tuupola/ksuid
 
 Included Base62 implementation has both PHP and [GMP](http://php.net/manual/en/ref.gmp.php) based encoders. By default encoder and decoder will use GMP functions if the extension is installed. If GMP is not available pure PHP encoder will be used instead.
 
-``` php
+```php
 use Tuupola\Ksuid;
 
 $ksuid = new Ksuid;
 
 print $ksuid; /* p6UEyCc8D8ecLijAI5zVwOTP3D0 */
-
-$ksuid = Ksuid::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
 
 print $ksuid->timestamp(); /* 94985761 */
 print $ksuid->unixtime(); /* 1494985761 */
@@ -39,6 +37,18 @@ $datetime = (new \DateTimeImmutable)
     ->setTimeZone(new \DateTimeZone("UTC"));
 
 print $datetime->format("Y-m-d H:i:s"); /* 2017-05-17 01:49:21 */
+```
+
+If you prefer static syntax you can use the provided static proxy.
+
+```php
+use Tuupola\KsuidProxy as Ksuid;
+
+$ksuid = KsuidProxy::generate();
+$ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
+
+$binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
+$ksuid = KsuidProxy::fromBytes($binary);
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ If you prefer static syntax you can use the provided static proxy.
 ```php
 use Tuupola\KsuidProxy as Ksuid;
 
-$ksuid = KsuidProxy::generate();
-$ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
+$ksuid = Ksuid::generate();
+$ksuid = Ksuid::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
 
 $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
-$ksuid = KsuidProxy::fromBytes($binary);
+$ksuid = Ksuid::fromBytes($binary);
 ```
 
 ## Testing

--- a/src/Ksuid.php
+++ b/src/Ksuid.php
@@ -43,21 +43,6 @@ class Ksuid
         return new self;
     }
 
-    public static function fromString($string)
-    {
-        $decoded = (new Base62)->decode($string);
-        return self::fromBytes($decoded);
-    }
-
-    public static function fromBytes($bytes)
-    {
-        $bytes = ltrim($bytes, "\0x00");
-        $timestamp = substr($bytes, 0, self::TIMESTAMP_SIZE);
-        $timestamp = unpack("Nuint", $timestamp);
-        $payload = substr($bytes, self::TIMESTAMP_SIZE, self::PAYLOAD_SIZE);
-        return new self($payload, $timestamp["uint"]);
-    }
-
     public function bytes()
     {
         return pack("N", $this->timestamp) . $this->payload;

--- a/src/Ksuid.php
+++ b/src/Ksuid.php
@@ -38,11 +38,6 @@ class Ksuid
         }
     }
 
-    public static function generate()
-    {
-        return new self;
-    }
-
     public function bytes()
     {
         return pack("N", $this->timestamp) . $this->payload;

--- a/src/KsuidProxy.php
+++ b/src/KsuidProxy.php
@@ -17,18 +17,18 @@ namespace Tuupola;
 
 class KsuidProxy
 {
-    public static function generate($payload = null, $timestamp = null): Ksuid
+    public static function generate($payload = null, $timestamp = null)
     {
         return new Ksuid($payload, $timestamp);
     }
 
-    public static function fromString(string $string): Ksuid
+    public static function fromString(string $string)
     {
         $decoded = (new Base62)->decode($string);
         return self::fromBytes($decoded);
     }
 
-    public static function fromBytes(string $bytes): Ksuid
+    public static function fromBytes(string $bytes)
     {
         $bytes = ltrim($bytes, "\0x00");
         $timestamp = substr($bytes, 0, Ksuid::TIMESTAMP_SIZE);

--- a/src/KsuidProxy.php
+++ b/src/KsuidProxy.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the KSUID package
+ *
+ * Copyright (c) 2017 Mika Tuupola
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   https://github.com/tuupola/ksuid
+ *
+ */
+
+namespace Tuupola;
+
+class KsuidProxy
+{
+    public static function generate($payload = null, $timestamp = null): Ksuid
+    {
+        return new Ksuid($payload, $timestamp);
+    }
+
+    public static function fromString(string $string): Ksuid
+    {
+        $decoded = (new Base62)->decode($string);
+        return self::fromBytes($decoded);
+    }
+
+    public static function fromBytes(string $bytes): Ksuid
+    {
+        $bytes = ltrim($bytes, "\0x00");
+        $timestamp = substr($bytes, 0, Ksuid::TIMESTAMP_SIZE);
+        $timestamp = unpack("Nuint", $timestamp);
+        $payload = substr($bytes, Ksuid::TIMESTAMP_SIZE, Ksuid::PAYLOAD_SIZE);
+        return new Ksuid($payload, $timestamp["uint"]);
+    }
+}

--- a/src/KsuidProxy.php
+++ b/src/KsuidProxy.php
@@ -22,13 +22,13 @@ class KsuidProxy
         return new Ksuid($payload, $timestamp);
     }
 
-    public static function fromString(string $string)
+    public static function fromString($string)
     {
         $decoded = (new Base62)->decode($string);
         return self::fromBytes($decoded);
     }
 
-    public static function fromBytes(string $bytes)
+    public static function fromBytes($bytes)
     {
         $bytes = ltrim($bytes, "\0x00");
         $timestamp = substr($bytes, 0, Ksuid::TIMESTAMP_SIZE);

--- a/tests/KsuidProxyTest.php
+++ b/tests/KsuidProxyTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the KSUID package
+ *
+ * Copyright (c) 2017 Mika Tuupola
+ *
+ * Licensed under the MIT license:
+ *   http://www.opensource.org/licenses/mit-license.php
+ *
+ * Project home:
+ *   https://github.com/tuupola/ksuid
+ *
+ */
+
+namespace Tuupola;
+
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+use DateTimeZone;
+
+class KsuidProxyTest extends TestCase
+{
+    public function testShouldBeTrue()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testGenerateShouldReturnKsuidInstance()
+    {
+        $this->assertInstanceOf(Ksuid::class, KsuidProxy::generate());
+    }
+
+    /* https://segment.com/blog/a-brief-history-of-the-uuid/ */
+    public function testShouldCreateFromString()
+    {
+        $ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
+        $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
+        $this->assertEquals(94985761, $ksuid->timestamp());
+        $this->assertEquals(1494985761, $ksuid->unixtime());
+        $this->assertEquals(
+            "d7b6fe8cd7cff211704d8e7b9421210b",
+            bin2hex($ksuid->payload())
+        );
+
+        $datetime = (new DateTimeImmutable)
+            ->setTimestamp($ksuid->unixtime())
+            ->setTimeZone(new DateTimeZone("UTC"));
+
+        $this->assertEquals(
+            "2017-05-17 01:49:21",
+            $datetime->format("Y-m-d H:i:s")
+        );
+    }
+
+    public function testShouldCreateFromBytes()
+    {
+        $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
+        $ksuid = KsuidProxy::fromBytes($binary);
+
+        $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
+        $this->assertEquals($binary, $ksuid->bytes());
+        $this->assertEquals(94985761, $ksuid->timestamp());
+        $this->assertEquals(1494985761, $ksuid->unixtime());
+        $this->assertEquals(
+            "d7b6fe8cd7cff211704d8e7b9421210b",
+            bin2hex($ksuid->payload())
+        );
+
+        $datetime = (new DateTimeImmutable)
+            ->setTimestamp($ksuid->unixtime())
+            ->setTimeZone(new DateTimeZone("UTC"));
+
+        $this->assertEquals(
+            "2017-05-17 01:49:21",
+            $datetime->format("Y-m-d H:i:s")
+        );
+    }
+}

--- a/tests/KsuidTest.php
+++ b/tests/KsuidTest.php
@@ -23,11 +23,6 @@ use DateTimeZone;
 
 class KsuidTest extends TestCase
 {
-    public function testGenerateShouldReturnKsuidInstance()
-    {
-        $this->assertInstanceOf(Ksuid::class, Ksuid::generate());
-    }
-
     public function testShouldBeTrue()
     {
         $this->assertTrue(true);
@@ -49,51 +44,5 @@ class KsuidTest extends TestCase
     {
         $ksuid = new Ksuid;
         $this->assertEquals(27, strlen((string)$ksuid));
-    }
-
-    /* https://segment.com/blog/a-brief-history-of-the-uuid/ */
-    public function testShouldCreateFromString()
-    {
-        $ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
-        $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
-        $this->assertEquals(94985761, $ksuid->timestamp());
-        $this->assertEquals(1494985761, $ksuid->unixtime());
-        $this->assertEquals(
-            "d7b6fe8cd7cff211704d8e7b9421210b",
-            bin2hex($ksuid->payload())
-        );
-
-        $datetime = (new DateTimeImmutable)
-            ->setTimestamp($ksuid->unixtime())
-            ->setTimeZone(new DateTimeZone("UTC"));
-
-        $this->assertEquals(
-            "2017-05-17 01:49:21",
-            $datetime->format("Y-m-d H:i:s")
-        );
-    }
-
-    public function testShouldCreateFromBytes()
-    {
-        $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
-        $ksuid = KsuidProxy::fromBytes($binary);
-
-        $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
-        $this->assertEquals($binary, $ksuid->bytes());
-        $this->assertEquals(94985761, $ksuid->timestamp());
-        $this->assertEquals(1494985761, $ksuid->unixtime());
-        $this->assertEquals(
-            "d7b6fe8cd7cff211704d8e7b9421210b",
-            bin2hex($ksuid->payload())
-        );
-
-        $datetime = (new DateTimeImmutable)
-            ->setTimestamp($ksuid->unixtime())
-            ->setTimeZone(new DateTimeZone("UTC"));
-
-        $this->assertEquals(
-            "2017-05-17 01:49:21",
-            $datetime->format("Y-m-d H:i:s")
-        );
     }
 }

--- a/tests/KsuidTest.php
+++ b/tests/KsuidTest.php
@@ -13,7 +13,7 @@
  *
  */
 
-namespace Tuupola\Ksuid;
+namespace Tuupola;
 
 use PHPUnit\Framework\TestCase;
 use Tuupola\Ksuid;
@@ -54,7 +54,7 @@ class KsuidTest extends TestCase
     /* https://segment.com/blog/a-brief-history-of-the-uuid/ */
     public function testShouldCreateFromString()
     {
-        $ksuid = Ksuid::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
+        $ksuid = KsuidProxy::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");
         $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
         $this->assertEquals(94985761, $ksuid->timestamp());
         $this->assertEquals(1494985761, $ksuid->unixtime());
@@ -76,7 +76,7 @@ class KsuidTest extends TestCase
     public function testShouldCreateFromBytes()
     {
         $binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
-        $ksuid = Ksuid::fromBytes($binary);
+        $ksuid = KsuidProxy::fromBytes($binary);
 
         $this->assertEquals("0o5Fs0EELR0fUjHjbCnEtdUwQe3", (string) $ksuid);
         $this->assertEquals($binary, $ksuid->bytes());


### PR DESCRIPTION
Keeping the main class clean. This is a BC break if you were using static methods before.
```php
use Tuupola\KsuidProxy as Ksuid;

$ksuid = Ksuid::fromString("0o5Fs0EELR0fUjHjbCnEtdUwQe3");

$binary = hex2bin("05a95e21d7b6fe8cd7cff211704d8e7b9421210b");
$ksuid = Ksuid::fromBytes($binary);
```