### PR TITLE
Simplify string representation code using str_pad()

### DIFF
--- a/src/Ksuid.php
+++ b/src/Ksuid.php
@@ -72,10 +72,7 @@ class Ksuid
     public function string(): string
     {
         $encoded = (new Base62)->encode($this->bytes());
-        if ($padding = self::ENCODED_SIZE - strlen($encoded)) {
-            $encoded = str_repeat("0", $padding) . $encoded;
-        }
-        return $encoded;
+        return str_pad($encoded, self::ENCODED_SIZE, "0", STR_PAD_LEFT);
     }
 
     public function payload(): string


### PR DESCRIPTION
According to the PHP docs, `str_pad` is available since PHP 4.0.1, so I think it is safe to use it.

reference: https://www.php.net/manual/en/function.str-pad.php

Using `str_pad` simplifies the code by removing an if branch and a temporary variable, while keeping code readability.